### PR TITLE
Rich text fix

### DIFF
--- a/patches/gatsby-source-contentful+2.0.55.patch
+++ b/patches/gatsby-source-contentful+2.0.55.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/gatsby-source-contentful/normalize.js b/node_modules/gatsby-source-contentful/normalize.js
-index d3a17c4..b2ef787 100644
+index d3a17c4..0caac4f 100644
 --- a/node_modules/gatsby-source-contentful/normalize.js
 +++ b/node_modules/gatsby-source-contentful/normalize.js
 @@ -199,6 +199,7 @@ function prepareTextNode(node, key, text, createNodeId) {
@@ -10,7 +10,7 @@ index d3a17c4..b2ef787 100644
    const str = stringify(content);
    const richTextNode = Object.assign({}, content, {
      id: createNodeId(`${node.id}${key}RichTextNode`),
-@@ -469,3 +470,57 @@ exports.createAssetNodes = ({
+@@ -469,3 +470,76 @@ exports.createAssetNodes = ({
      createNode(assetNode);
    });
  };
@@ -18,28 +18,30 @@ index d3a17c4..b2ef787 100644
 +function mutateFieldsToOnlySlug(nodeToMutate, item, itemIndex, currentSlug) {
 +  const nodeToMutateFields = nodeToMutate.fields;
 +
-+  if (Object.prototype.hasOwnProperty.call(nodeToMutateFields, "slug") && nodeToMutateFields.slug !== currentSlug) {
-+    const {
-+      slug
-+    } = nodeToMutateFields;
++  if (
++    Object.prototype.hasOwnProperty.call(nodeToMutateFields, "slug") &&
++    nodeToMutateFields.slug !== currentSlug
++  ) {
++    const { slug } = nodeToMutateFields;
 +    nodeToMutate.fields = {
 +      slug
 +    };
 +  } else {
 +    // If no slug or if reference to same content set to null
-+    if(item && item.content) {
-+      item.content.splice(itemIndex, 1);    
++    if (item && item.content) {
++      item.content.splice(itemIndex, 1);
 +    }
 +  }
 +}
 +
 +function mutateLinkReferenceIfNeeded(node, item, i) {
-+  if(!node.data.target.sys.contentType) return
++  if (!node.data.target.sys.contentType) return;
 +  const embeddedContentModel = node.data.target.sys.contentType.sys.id;
 +
 +  if (embeddedContentModel === "assemblyCta") {
 +    const contentModelFields = node.data.target.fields;
-+    const fieldLink = contentModelFields.cta["en-GB"][0].fields.link["en-GB"][0];
++    const fieldLink =
++      contentModelFields.cta["en-GB"][0].fields.link["en-GB"][0];
 +    return mutateFieldsToOnlySlug(fieldLink, item, i);
 +  }
 +}
@@ -52,19 +54,36 @@ index d3a17c4..b2ef787 100644
 +      Object.keys(item).forEach((ik, i) => {
 +        const rtItem = item[ik];
 +
-+        if (Object.prototype.hasOwnProperty.call(rtItem, "nodeType") && rtItem.nodeType === "embedded-entry-block") {
++        if (
++          Object.prototype.hasOwnProperty.call(rtItem, "nodeType") &&
++          rtItem.nodeType === "embedded-entry-block"
++        ) {
 +          mutateLinkReferenceIfNeeded(rtItem, item, i);
 +        }
-+
-+       if (Object.prototype.hasOwnProperty.call(rtItem, "content") && Array.isArray(rtItem.content) && rtItem.content.length > 0) {
-+          rtItem.content.forEach((contentNode, ii) => {
-+            if (Object.prototype.hasOwnProperty.call(contentNode, "nodeType") && contentNode.nodeType === "entry-hyperlink") {
-+              // fields needed just slug for now
-+              mutateFieldsToOnlySlug(contentNode.data.target, contentNode, ii);
-+            }
-+          });
-+        }
++        checkRichTextContent(rtItem);
 +      });
 +    }
-+  })
++  });
++}
++
++const checkRichTextContent = rtContent => {
++  const hasContent = content =>
++    Object.prototype.hasOwnProperty.call(content, "content") &&
++    Array.isArray(content.content) &&
++    content.content.length > 0;
++
++  if (hasContent(rtContent)) {
++    rtContent.content.forEach((contentNode, ii) => {
++      if (
++        Object.prototype.hasOwnProperty.call(contentNode, "nodeType") &&
++        contentNode.nodeType === "entry-hyperlink"
++      ) {
++        // fields needed just slug for now
++        mutateFieldsToOnlySlug(contentNode.data.target, contentNode, ii);
++      } else if (hasContent(contentNode)) {
++        // Check for deeper richtext content, e.g. Lists inside paragraphs
++        checkRichTextContent(contentNode);
++      }
++    });
++  }
 +};


### PR DESCRIPTION
By default RTE when linked to a piece of content references every field on the linked content. The referenced content could then have links to other content in its fields which would extremely easily create circular reference. The patch mutates the linked contents field to just slug to prevent this. This wasn't checking deep enough in the rich text content, as when a link was included inside a link inside a paragraph this was not mutated and caused a loop.